### PR TITLE
organize_dataset.py fix timestamp format and use createdAt

### DIFF
--- a/src/pysoda/organize_datasets.py
+++ b/src/pysoda/organize_datasets.py
@@ -630,7 +630,8 @@ def bf_get_dataset_files_folders(soda_json_structure, requested_sparc_only = Tru
                             manifest_error_message.append(package_details["parent"]["content"]["name"])
                             pass
                     else:
-                        timestamp = package_details["content"]["updatedAt"]
+                        timestamp = (package_details["content"]["createdAt"]
+                                     .replace('.', ',').replace('+00:00', 'Z'))
                         dataset_folder["files"][file_name] = {
                             "type": "bf","action": ["existing"], "path": item.id, "timestamp": timestamp}
 


### PR DESCRIPTION
Timestamps sourced directly from the pennsieve packages endpoint are
now formatted to match curation pipeline expectations.

On most filesystems mtime is the only reliable time for files since
file creation time is not tracked. On Pennsieve this is not the case
because files (packages) are immutable, therefore use createdAt to get
the earliest time that a file was known to be in the system.